### PR TITLE
Only allow a maximum of `cpu_count` of executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ module.exports = function(config) {
 
 `parallelOptions.executors [int=cpu_cores-1]`: The number of browser instances to
 use to test. If you test on multiple types of browsers, this spin up the number of
-executors for each browser type.
+executors for each browser type. If you supply a value greater than `cpu_cores-1`,
+it will default back to `cpu_cores-1`.
 
 `parallelOptions.shardStyle [string='round-robin']`: This plugin works by
 overriding the test suite `describe()` function. When it encounters a describe, it

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ use to test. If you test on multiple types of browsers, this spin up the number 
 executors for each browser type. If you supply a value greater than `cpu_cores-1`,
 it will default back to `cpu_cores-1`.
 
-`parallelOptions.shardStyle [string='round-robin']`: This plugin works by
+`parallelOptions.shardStrategy [string='round-robin']`: This plugin works by
 overriding the test suite `describe()` function. When it encounters a describe, it
 must decide if it will skip the tests inside of it, or not.
 

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -12,7 +12,7 @@ function getConfig(fullConfig) {
   config.browserIdAlias = {};
   config.shardStrategy = config.shardStrategy || 'round-robin';
   config.aggregatedReporterTest = ('aggregatedReporterTest' in config) ? config.aggregatedReporterTest : /coverage|istanbul|junit/i;
-  config.executors = Math.max(1, config.executors || require('os').cpus().length - 1);
+  config.executors = Math.max(1, Math.min(config.executors || Infinity, require('os').cpus().length - 1));
   return config;
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds new behavior to the `executors` option where, if a user supplies a config where `executors > cpu_count - 1`, it will default back to `cpu_count - 1`


* **What is the current behavior?** (You can also link to an open issue here)
It will simply use the larger `executors` count, which will error out


* **What is the new behavior (if this is a feature change)?**
It will use `Math.min(cpu_count - 1, executors || Infinity)`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
