### PR TITLE
afterAll() function should be called only for one of the executors in which the spec is executed.

### DIFF
--- a/lib/karma-parallelizer.js
+++ b/lib/karma-parallelizer.js
@@ -121,8 +121,8 @@ function createFakeTestContext(ctx, shouldUseDescription) {
   ctx.before        = wrap(ctx.before,     false, false, false);
   ctx.beforeAll     = wrap(ctx.beforeAll,  false, false, false);
   ctx.beforeEach    = wrap(ctx.beforeEach, false, false, false);
-  ctx.beforeAll     = wrap(ctx.beforeAll,  false, false, false);
   ctx.after         = wrap(ctx.after,      false, false, false);
+  ctx.afterAll      = wrap(ctx.afterAll,   false, false, false);
   ctx.afterEach     = wrap(ctx.afterEach,  false, false, false);
 
   return {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for the issue outlined in https://github.com/joeljeske/karma-parallel/issues/11


* **What is the current behavior?** (You can also link to an open issue here)
When config.parallelOptions.executors is > 1 the afterAll() functions of tests are called in all executors.


* **What is the new behavior (if this is a feature change)?**
afterAll() function is called only for one of the executors in which the test is executed.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No changes are required. The change should not be breaking.


* **Other information**:
