### PR TITLE
Should fail the test cases split to a browser that is disconnected #38

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -4,6 +4,8 @@ const path = require('path');
 
 // jshint node: true
 
+let disconnectedBrowser;
+
 function getConfig(fullConfig) {
   // ensure we can manipulate config settings
   const config = (fullConfig.parallelOptions =
@@ -62,6 +64,7 @@ function setBrowserCount(config, browsers, log) {
 // if we restart our browsers or if connections get reset.
 function handleBrowserRegister(log, config, browser) {
   // Create a alias Id for each browser.name. Used in identifying coverage reports
+
   config.browserIdAlias[browser.name] =
     config.browserIdAlias[browser.name] ||
     Math.floor(Math.random() * Date.now());
@@ -97,7 +100,71 @@ module.exports = function(/* config */ fullConfig, emitter, logger) {
   const config = getConfig(fullConfig);
   setupMiddleware(log, fullConfig);
   setBrowserCount(config, fullConfig.browsers, log);
-  emitter.on('browser_register', browser =>
-    handleBrowserRegister(log, config, browser)
-  );
+  emitter.on('browser_register', (browser) => {
+    log.debug('disconnectedBrowser', disconnectedBrowser);
+
+    // If there is disconnected browser
+    if (disconnectedBrowser) {
+      disconnectedBrowser = false;
+      const currentShardedIndexes = [];
+      const expectedShardedIndexes = [];
+
+      for (let i = 0; i < config.executors; i++) {
+        expectedShardedIndexes.push(i);
+      }
+      
+      Object.keys(config.shardIndexMap)
+        .forEach((key) => {
+          currentShardedIndexes.push(config.shardIndexMap[key]);
+        });
+
+      // Get missing executr index
+      log.debug('currentShardedIndexes, expectedShardedIndexes', currentShardedIndexes, expectedShardedIndexes);
+      const diff = arr_diff(currentShardedIndexes, expectedShardedIndexes);
+      log.debug('shard index', diff);
+
+      if (diff.length !== 0) {
+        // Re-register the browser with valid shard id.
+        config.shardIndexMap[browser.id] = diff[0];
+        log.debug(
+          `Re - registering browser id ${browser.id} with aggregated browser id ${
+            config.browserIdAlias[browser.name]
+          } at shard index ${config.shardIndexMap[browser.id]}`
+        );
+
+        log.debug('SHARDEDINFO', config.shardIndexMap);
+      }
+    } else {
+      handleBrowserRegister(log, config, browser);
+    }
+  });
+
+  emitter.on('browser_error', (browser, data) => {
+    delete config.shardIndexMap[browser.id];
+  
+    disconnectedBrowser = true;
+    log.debug('browser_error', browser, data);
+  });
 };
+
+function arr_diff (a1, a2) {
+  const a = [], diff = [];
+
+  for (let i = 0; i < a1.length; i++) {
+    a[a1[i]] = true;
+  }
+
+  for (let i = 0; i < a2.length; i++) {
+    if (a[a2[i]]) {
+      delete a[a2[i]];
+    } else {
+      a[a2[i]] = true;
+    }
+  }
+
+  for (let k in a) {
+    diff.push(k);
+  }
+
+  return diff;
+}

--- a/lib/karma-parallelizer.js
+++ b/lib/karma-parallelizer.js
@@ -56,7 +56,7 @@ function createDescriptionLengthStrategy(shardIndexInfo) {
   var shardIndex = shardIndexInfo.shardIndex,
     executors = shardIndexInfo.executors;
   return function overrideSpecSuite(description /*, specDefinitions*/) {
-    return description.length % executors === shardIndex;
+    return Number(description.length % executors) === Number(shardIndex);
   };
 }
 
@@ -81,7 +81,7 @@ function createRoundRobinStrategy(shardIndexInfo) {
   // round-robin responsibility
   var count = 0;
   return function(/*description, specDefinitions*/) {
-    return count++ % executors === shardIndex;
+    return Number(count++ % executors) === Number(shardIndex);
   };
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ + ] The commit message follows our guidelines
- [ + ] Tests for the changes have been added (for bug fixes / features)
- [ - ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix #38


* **What is the current behavior?** (You can also link to an open issue here)
1. Each time the browser unregister and re-register his shard id become different which causes the strategy to not execute any tests to this browser instance.
2. For some reason the shard index first time is number and there are no issues in the strategy function but the second time (re-connect) it is string which reflects to no tests for this browser, because his index doesn't "answering" the needed condition. For example: 15 % 3 === '0' -> False, should be True.


* **What is the new behaviour (if this is a feature change)?**
1. Find available shard index (Example: from 0 - 3) and assign it to the new browser instance.
2. Do casting like: Number(a % b) === Number(c).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes, no user changes needed.


* **Other information**:
