### PR TITLE
Fix disconnect race condition

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 // jshint node: true
 
-let disconnectedBrowser;
+const disconnectedBrowsers = [];
 
 function getConfig(fullConfig) {
   // ensure we can manipulate config settings
@@ -101,70 +101,28 @@ module.exports = function(/* config */ fullConfig, emitter, logger) {
   setupMiddleware(log, fullConfig);
   setBrowserCount(config, fullConfig.browsers, log);
   emitter.on('browser_register', (browser) => {
-    log.debug('disconnectedBrowser', disconnectedBrowser);
+    log.debug('disconnectedBrowsers', disconnectedBrowsers);
 
     // If there is disconnected browser
-    if (disconnectedBrowser) {
-      disconnectedBrowser = false;
-      const currentShardedIndexes = [];
-      const expectedShardedIndexes = [];
+    if (disconnectedBrowsers.length) {
+      const connectKey = disconnectedBrowsers.pop();
+      config.shardIndexMap[browser.id] = connectKey;
+      log.debug(
+        `Re - registering browser id ${browser.id} with aggregated browser id ${
+          config.browserIdAlias[browser.name]
+        } at shard index ${config.shardIndexMap[browser.id]}`
+      );
 
-      for (let i = 0; i < config.executors; i++) {
-        expectedShardedIndexes.push(i);
-      }
-      
-      Object.keys(config.shardIndexMap)
-        .forEach((key) => {
-          currentShardedIndexes.push(config.shardIndexMap[key]);
-        });
-
-      // Get missing executr index
-      log.debug('currentShardedIndexes, expectedShardedIndexes', currentShardedIndexes, expectedShardedIndexes);
-      const diff = arr_diff(currentShardedIndexes, expectedShardedIndexes);
-      log.debug('shard index', diff);
-
-      if (diff.length !== 0) {
-        // Re-register the browser with valid shard id.
-        config.shardIndexMap[browser.id] = diff[0];
-        log.debug(
-          `Re - registering browser id ${browser.id} with aggregated browser id ${
-            config.browserIdAlias[browser.name]
-          } at shard index ${config.shardIndexMap[browser.id]}`
-        );
-
-        log.debug('SHARDEDINFO', config.shardIndexMap);
-      }
+      log.debug('SHARDEDINFO', config.shardIndexMap);
     } else {
       handleBrowserRegister(log, config, browser);
     }
   });
 
   emitter.on('browser_error', (browser, data) => {
+    disconnectedBrowsers.push(config.shardIndexMap[browser.id]);
     delete config.shardIndexMap[browser.id];
-  
-    disconnectedBrowser = true;
+
     log.debug('browser_error', browser, data);
   });
 };
-
-function arr_diff (a1, a2) {
-  const a = [], diff = [];
-
-  for (let i = 0; i < a1.length; i++) {
-    a[a1[i]] = true;
-  }
-
-  for (let i = 0; i < a2.length; i++) {
-    if (a[a2[i]]) {
-      delete a[a2[i]];
-    } else {
-      a[a2[i]] = true;
-    }
-  }
-
-  for (let k in a) {
-    diff.push(k);
-  }
-
-  return diff;
-}


### PR DESCRIPTION
Issue:
The previous implementation was not taking under
consideration that two browsers can disconnect at
the same time.

Fix:
Collect all shard indexes in array of disconnected browsers.

Testing Done:
- Verify the test sets will be reconnected to the correct
shard index and there will be no 1 of 1 test sets, when
2 browsers disconnect at the same time.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
If two browsers disconnect at the same time the second will create new shard index
and will cause 1 of 1 test set.


* **What is the new behavior (if this is a feature change)?**
Each disconnected browser shard index will be stored in disconnected browsers array
and when the new browsers try to reconnect they will get their old shard indexes, ensuring
no 1 of 1 test sets.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes.


* **Other information**:
