### PR TITLE
fix: handle case where karma is run in new window

### DIFF
--- a/lib/karma-parallelizer.js
+++ b/lib/karma-parallelizer.js
@@ -5,7 +5,7 @@
 function initKarmaParallelizer(root, karma, shardIndexInfoMap) {
   var idParamExtractor = /(\?|&)id=(\d+)(&|$)/;
   const parentWindow = window.opener || window.parent;
-  var matches = idParamExtractor.exec(parentWindow.location.search);
+  var matches = idParamExtractor.exec(parentWindow.location.search || opener.location.search);
   var id = (matches && matches[2]) || null;
 
   if (


### PR DESCRIPTION
If `client.useIframe` is set to false the test context is in a new window instead of an iframe. So we need to use the `opener` to get the original location to grab the browser ID, rather than `parent`.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
**Bug fix**
Currently karma allows setting the `client.useIframe` configuration to false to run tests in a new window. But `karma-parallel` doesn't handle that case and skips sharding.

* **What is the current behavior?** (You can also link to an open issue here)
The current behavior is to try to fetch the browser ID from the parent window assuming current context is an iframe. But the context is actually a new window.


* **What is the new behavior (if this is a feature change)?**
The initializer will now honor the `client.useIframe` configuration and not skip sharding if it is set to false.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
**No**


* **Other information**:
**N/A**