### PR TITLE
Improve Aggregated Log Output with additional getters (#39)

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -20,6 +20,16 @@ class AggegatedBrowserLastResult {
       _.map(this._realLastResults, 'failed')
     );
   }
+  get success() {
+    return _.sum(
+      _.map(this._realLastResults, 'success')
+    )
+  }
+  get skipped() {
+    return _.sum(
+      _.map(this._realLastResults, 'skipped')
+    )
+  }
   get netTime() {
     return _.max(
       _.map(this._realLastResults, 'netTime')


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (n/a)
- [x] Docs have been added / updated (n/a)


* **What kind of change does this PR introduce?** 
Following the discussion in #39 I debugged the issue with brief-reporter. Two getters were missing. 


* **What is the current behavior?**
#39 - Brief fails because it receives undefined from karma-parallel


* **What is the new behavior (if this is a feature change)?**
The output log object contains two additional getters for success and for skipped tests. No other changes.


* **Does this PR introduce a breaking change?**
No


* **Other information**:
I don't feel the need to add tests for that, but if maintainers ever look at this PR and find it worthy, just drop me a line and I'll try to add some.