### PR TITLE
Pass exit code through reporters to karma

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -161,13 +161,13 @@ const AggregatedCoverageReporter = function(injector, logger, config, baseReport
     const promises = reporters.map(({name, reporter}) => new Promise((resolve) => {
       if (_.isFunction(reporter.onExit)) {
         log.debug(`relaying done() on reporter:${name}`);
-        reporter.onExit(() => resolve());
+        reporter.onExit((exitCode) => resolve(exitCode));
       } else {
         resolve();
       }
     }));
 
-    Promise.all(promises).then(() => done());
+    Promise.all(promises).then((exitCodes) => done(exitCodes.some((exitCode) => exitCode === 1) ? 1 : 0));
   };
 };
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features) - project doesn't appear to have any, tests in `tests` dir aren't testing lib behavior
- [ ] Docs have been added / updated (for bug fixes / features) - doesn't seem necessary here unless something needs to be in the releases log (doesn't appear to have been updated in a while)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Possibly related to #35, but `karma-parallel` doesn't appropriately exit with code 1 if coverage thresholds aren't met when this is used in conjunction with `karma-coverage`. In this issue/subsequent PR support was added in `karma`/`karma-coverage` to pass the exit code through in the `onExit` callback:

https://github.com/karma-runner/karma-coverage/issues/418
https://github.com/karma-runner/karma/pull/3541
https://github.com/karma-runner/karma-coverage/commit/c93f0612da6898fb5cfbb9ece57556a2704c4397#diff-691854e392b02b6faf6147eef5d32e3bb9f187025dc025742167d4bdce7443feR286

The existing implementation of `onExit` in `karma-parallel` doesn't pass along the returned values from `onExit` in the individual reporters.

* **What is the new behavior (if this is a feature change)?**

The exit code is now passed through from the original reporters.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Possibly? Users might now have commands/CI builds fail because of coverage, but that would be correct/no longer a false positive. I don't know enough about karma/the reporter API to know if `onExit` is only ever supposed to be passed an exit code, so if it can be passed other data/arguments this behavior wouldn't be entirely correct.

* **Other information**:

I'm not 100% sure if this is the right solution - this wouldn't be an issue for anyone not utilizing a coverage reporter/coverage thresholds. Open to feedback on how to improve this.