### PR TITLE
Call through for global before-* and after-* blocks (fixes #64)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,14 +4,16 @@
     "commonjs": true,
     "es6": true,
     "node": true,
-    "jasmine": true
+    "jasmine": true,
+    "mocha": true
   },
   "extends": [
     "eslint:recommended",
     "plugin:security/recommended"
   ],
   "globals": {
-    "FakeNews": true
+    "FakeNews": true,
+    "GlobalConditions": true
   },
   "plugins": [
     "security"

--- a/lib/karma-parallelizer.js
+++ b/lib/karma-parallelizer.js
@@ -130,6 +130,9 @@ function createFakeTestContext(ctx, shouldUseDescription) {
         // If its a fake description, then we need to call through to eval inner its() looking for focuses
         // TODO, do we ever need parameters?
         def();
+      } else if(depth === 0 && !isFocus && !isDescription && !isSpec) {
+        // If it is a global before-* or after-*, then we want to call through and return the result
+        return fn.apply(this, arguments);
       }
     };
   }

--- a/test/global-conditions.js
+++ b/test/global-conditions.js
@@ -1,0 +1,12 @@
+window.GlobalConditions = {
+  beforeAllCount: 0,
+  beforeEachCount: 0,
+  afterEachCount: 0,
+  afterAllCount: 0,
+  testRunCount: 0,
+  beforeAll: function beforeAll() { this.beforeAllCount++; },
+  beforeEach: function beforeEach() { this.beforeEachCount++; },
+  afterEach: function afterEach() { this.afterEachCount++; },
+  afterAll: function afterAll() { this.afterAllCount++; },
+  testRun: function testRun() { this.testRunCount++; },
+};

--- a/test/set-global-spec.js
+++ b/test/set-global-spec.js
@@ -1,0 +1,44 @@
+(before || beforeAll)(() => {
+  GlobalConditions.beforeAll();
+});
+
+beforeEach(() => {
+  GlobalConditions.beforeEach();
+});
+
+afterEach(() => {
+  GlobalConditions.afterEach();
+});
+
+(after || afterAll)(() => {
+  GlobalConditions.afterAll();
+});
+
+
+
+describe('set global conditions', function() {
+  describe('first subject', function() {
+    it('has a test', function() {
+      expect(GlobalConditions.testRun());
+    });
+    it('has another test', function() {
+      expect(GlobalConditions.testRun());
+    });
+  });
+  describe('second subject', function() {
+    it('has a test', function() {
+      expect(GlobalConditions.testRun());
+    });
+    it('has another test', function() {
+      expect(GlobalConditions.testRun());
+    });
+  });
+  describe('third subject', function() {
+    it('has a test', function() {
+      expect(GlobalConditions.testRun());
+    });
+    it('has another test', function() {
+      expect(GlobalConditions.testRun());
+    });
+  });
+});


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features) - none of the exiting or new tests explicitly verify things.  I used the coverage report's execution count to verify.
- [x] Docs have been added / updated (for bug fixes / features) - no changes, the new behavior is what should be expected


* **What kind of change does this PR introduce?**
Bug fix

* **What is the current behavior?**
Global calls to the condition hooks are not executed on any shard.
See https://github.com/joeljeske/karma-parallel/issues/64


* **What is the new behavior?**
The wrapper function will call through to the underlying library function for global calls to `before`/`beforeAll`, `beforeEach`, `afterEach`, and `after`/`afterAll`.


* **Does this PR introduce a breaking change?**
Unclear if in scope.  
  - If the library consumer is using workarounds to run pre-/post-test logic and that logic is not idempotent, then they may see issues due to multiple executions of the pre-/post-test logic.


* **Other information**:
